### PR TITLE
move GatewayQueries into krt

### DIFF
--- a/projects/gateway2/extensions/extensions.go
+++ b/projects/gateway2/extensions/extensions.go
@@ -4,11 +4,13 @@ import (
 	"context"
 
 	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gateway2/krtquery"
 	"github.com/solo-io/gloo/projects/gateway2/query"
 	"github.com/solo-io/gloo/projects/gateway2/translator"
 	"github.com/solo-io/gloo/projects/gateway2/translator/plugins/registry"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1"
 	"github.com/solo-io/solo-kit/pkg/api/v2/reporter"
+	"istio.io/istio/pkg/kube"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	apiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -26,6 +28,7 @@ type K8sGatewayExtensions interface {
 
 // K8sGatewayExtensionsFactoryParameters contains the parameters required to start Gloo K8s Gateway Extensions (including Translator Plugins)
 type K8sGatewayExtensionsFactoryParameters struct {
+	IstioClient             kube.Client
 	Mgr                     controllerruntime.Manager
 	AuthConfigClient        v1.AuthConfigClient
 	RouteOptionClient       gatewayv1.RouteOptionClient
@@ -42,13 +45,14 @@ type K8sGatewayExtensionsFactory func(
 
 // NewK8sGatewayExtensions returns the Open Source implementation of K8sGatewayExtensions
 func NewK8sGatewayExtensions(
-	_ context.Context,
+	ctx context.Context,
 	params K8sGatewayExtensionsFactoryParameters,
 ) (K8sGatewayExtensions, error) {
-	queries := query.NewData(
-		params.Mgr.GetClient(),
-		params.Mgr.GetScheme(),
-	)
+	// queries := query.NewData(
+	// 	params.Mgr.GetClient(),
+	// 	params.Mgr.GetScheme(),
+	// )
+	queries := krtquery.New(ctx, params.IstioClient)
 
 	return &k8sGatewayExtensions{
 		mgr:                     params.Mgr,

--- a/projects/gateway2/krtcollection/dynamic.go
+++ b/projects/gateway2/krtcollection/dynamic.go
@@ -1,0 +1,39 @@
+package krtcollection
+
+import (
+	"context"
+
+	"github.com/solo-io/go-utils/contextutils"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/kube/kubetypes"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// SetupCollectionDynamic uses the dynamic client to setup an informer for a resource
+// and then uses an intermediate krt collection to type the unstructured resource.
+// This is a temporary workaround until we update to the latest istio version and can
+// uncomment the code below for registering types.
+// HACK: we don't want to use this long term, but it's letting me push forward with deveopment
+func SetupCollectionDynamic[T any](
+	ctx context.Context,
+	client kube.Client,
+	gvr schema.GroupVersionResource,
+	opts ...krt.CollectionOption,
+) krt.Collection[*T] {
+	delayedClient := kclient.NewDelayedInformer[*unstructured.Unstructured](client, gvr, kubetypes.DynamicInformer, kclient.Filter{})
+	mapper := krt.WrapClient(delayedClient, opts...)
+	return krt.NewCollection(mapper, func(krtctx krt.HandlerContext, i *unstructured.Unstructured) **T {
+		var empty T
+		out := &empty
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(i.UnstructuredContent(), out)
+		if err != nil {
+			contextutils.LoggerFrom(ctx).DPanic("failed converting unstructured into %T: %v", empty, i)
+			return nil
+		}
+		return &out
+	})
+}

--- a/projects/gateway2/krtcollection/wrapper.go
+++ b/projects/gateway2/krtcollection/wrapper.go
@@ -1,0 +1,44 @@
+package krtcollection
+
+import (
+	"google.golang.org/protobuf/proto"
+
+	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	core "github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
+	"istio.io/istio/pkg/kube/krt"
+)
+
+// UpstreamWrapper provides a keying function for Gloo's `v1.Upstream`
+type UpstreamWrapper = ResourceWrapper[*gloov1.Upstream]
+
+type GlooResource interface {
+	proto.Message
+	interface {
+		GetMetadata() *core.Metadata
+	}
+}
+
+type ResourceWrapper[T GlooResource] struct {
+	Inner T
+}
+
+func (us ResourceWrapper[T]) ResourceName() string {
+	return krt.Named{
+		Name:      us.Inner.GetMetadata().GetName(),
+		Namespace: us.Inner.GetMetadata().GetNamespace(),
+	}.ResourceName()
+}
+
+func (us ResourceWrapper[T]) Equals(in ResourceWrapper[T]) bool {
+	return proto.Equal(us.Inner, in.Inner)
+}
+
+func (us ResourceWrapper[T]) GetMetadata() *core.Metadata {
+	return us.Inner.GetMetadata()
+}
+
+// equivalent of var _ Interface = Struct{} for generics
+func _genericTypeAssert[T GlooResource]() (krt.ResourceNamer, krt.Equaler[ResourceWrapper[T]]) {
+	return ResourceWrapper[T]{}, ResourceWrapper[T]{}
+}

--- a/projects/gateway2/krtquery/attachment.go
+++ b/projects/gateway2/krtquery/attachment.go
@@ -1,0 +1,225 @@
+package krtquery
+
+import (
+	"errors"
+
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/slices"
+	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+var (
+	AttachmentErrTargetNotFound  = errors.New("Unresolved target or parent reference.")
+	AttachmentErrSectionNotFound = errors.New("Unresolved section in target resource.")
+)
+
+// Attachment indexes a resource by its attachments.
+// The mechanism for attachment can take several shapes:
+// * TargetRef
+// * ParentRef
+// * Annotations/labels (like istio.io/use-waypoint)
+type Attachment[A comparableNamespaced, T comparableNamespaced] struct {
+	Resource A
+	Target   T
+	Section  string
+	Error    error
+}
+
+func (a Attachment[A, T]) Equals(o Attachment[A, T]) bool {
+	// don't compare the Target!
+	return a.Resource == o.Resource && a.Error == o.Error && a.Section == o.Section
+}
+
+// ResourceName provides a unique key for krt collections.
+func (h Attachment[A, T]) ResourceName() string {
+	return h.Resource.GetNamespace() + "/" + h.Resource.GetName() +
+		"~" +
+		h.Target.GetNamespace() + "/" + h.Target.GetName() + "/" + h.Section
+}
+
+func ExtractResources[A comparableNamespaced, T comparableNamespaced](a []Attachment[A, T]) []A {
+	return slices.Map(a, func(a Attachment[A, T]) A {
+		return a.Resource
+	})
+}
+
+// AttachmentSourceKey is based on both the source resource and target resource (and optionally section name).
+type AttachmentSourceKey string
+
+// MakeAttachmentSourceKey is used to key/query for individual attachments.
+func MakeAttachmentSourceKey(resource Namespaced, target Namespaced, section string) AttachmentSourceKey {
+	return AttachmentSourceKey(resource.GetNamespace() + "/" + resource.GetName() +
+		"~" +
+		target.GetNamespace() + "/" + target.GetName() + "/" + section)
+}
+
+// AttachmentKey is based on the target resource (and optionally section).
+type AttachmentKey string
+
+// MakeAttachmentKey is used to key/query for attachments to a given target resource.
+func MakeAttachmentKey(target Namespaced, section string) AttachmentKey {
+	return AttachmentKey(target.GetNamespace() + "/" + target.GetName() + "/" + section)
+}
+
+func (i *IndexedAttachments[A, T]) FetchOne(
+	ctx krt.HandlerContext,
+	resource Namespaced,
+	target Namespaced,
+	section string,
+) *Attachment[A, T] {
+	key := string(MakeAttachmentSourceKey(resource, target, section))
+	return krt.FetchOne(ctx, i.Collection, krt.FilterKey(key))
+}
+
+func filterAttachedTo[A comparableNamespaced, T comparableNamespaced](target T, section string) krt.FetchOption {
+	key := MakeAttachmentKey(target, section)
+	return krt.FilterGeneric(func(o any) bool {
+		a := o.(Attachment[A, T])
+		return MakeAttachmentKey(a.Target, a.Section) == key
+	})
+}
+
+func (i *IndexedAttachments[A, T]) FetchAttachmentsTo(
+	ctx krt.HandlerContext,
+	target T,
+	section string,
+) []Attachment[A, T] {
+	var sectionFilter []krt.FetchOption
+	if section != "" {
+		sectionFilter = []krt.FetchOption{krt.FilterKey(string(MakeAttachmentKey(target, "")))}
+	}
+	return krt.Fetch(
+		ctx,
+		i.Collection,
+		append(
+			sectionFilter,
+			krt.FilterIndex(i.Index, namespacedName(target)),
+		)...,
+	)
+}
+
+func (i *IndexedAttachments[A, T]) FetchErroredAttachments(
+	ctx krt.HandlerContext,
+	target T,
+	section string,
+) []Attachment[A, T] {
+	var sectionFilter []krt.FetchOption
+	if section != "" {
+		sectionFilter = []krt.FetchOption{krt.FilterKey(string(MakeAttachmentKey(target, "")))}
+	}
+	return krt.Fetch(
+		ctx,
+		i.Collection,
+		append(
+			sectionFilter,
+			krt.FilterIndex(i.ErrorIndex, namespacedName(target)),
+		)...,
+	)
+}
+
+type comparableNamespaced interface {
+	comparable
+	Namespaced
+}
+
+type IndexedAttachments[A comparableNamespaced, T comparableNamespaced] struct {
+	Collection krt.Collection[Attachment[A, T]]
+	Index      krt.Index[types.NamespacedName, Attachment[A, T]]
+	ErrorIndex krt.Index[types.NamespacedName, Attachment[A, T]]
+}
+
+// CreateAttachmentIndexes allows consumers to query these attachments by the resource
+// that's being targeted.
+func CreateAttachmentIndexes[A comparableNamespaced, T comparableNamespaced](
+	collection krt.Collection[Attachment[A, T]],
+) IndexedAttachments[A, T] {
+	return IndexedAttachments[A, T]{
+		Collection: collection,
+		Index: krt.NewIndex(collection, func(o Attachment[A, T]) []types.NamespacedName {
+			if o.Error != nil {
+				return nil
+			}
+			return []types.NamespacedName{namespacedName(o.Target)}
+		}),
+		ErrorIndex: krt.NewIndex(collection, func(o Attachment[A, T]) []types.NamespacedName {
+			if o.Error == nil {
+				return nil
+			}
+			return []types.NamespacedName{namespacedName(o.Target)}
+		}),
+	}
+}
+
+// common struct for parentRef and targetRef
+type ref struct {
+	ns, name, section string
+}
+
+// targetResourceKey gives the target without section name
+func (r ref) targetResourceKey() string {
+	return r.ns + "/" + r.name
+}
+
+func (r ref) GetName() string {
+	return r.name
+}
+
+func (r ref) GetNamespace() string {
+	return r.ns
+}
+
+func parentRef[T Namespaced](resource T, parentRef gwv1.ParentReference) ref {
+	return ref{
+		ns:      string(ptr.OrDefault(parentRef.Namespace, gwv1.Namespace(resource.GetNamespace()))),
+		name:    string(parentRef.Name),
+		section: string(ptr.OrEmpty(parentRef.SectionName)),
+	}
+}
+
+type TargetRef interface {
+	GetNamespace() *wrappers.StringValue
+	GetName() string
+	GetSectionName() *wrappers.StringValue
+}
+
+func targetRef[T Namespaced](resource T, targetRef TargetRef) ref {
+	return ref{
+		ns:      ptr.NonEmptyOrDefault(targetRef.GetNamespace().GetValue(), resource.GetNamespace()),
+		name:    string(targetRef.GetName()),
+		section: string(ptr.OrEmpty(targetRef.GetSectionName()).Value),
+	}
+}
+
+func NewGatewayAttachment[T comparableNamespaced](
+	ctx krt.HandlerContext,
+	Gateways krt.Collection[*gwv1.Gateway],
+	resource T,
+	ref ref,
+) (Attachment[T, *gwv1.Gateway], error) {
+	gw := ptr.Flatten(krt.FetchOne(ctx, Gateways, krt.FilterKey(ref.targetResourceKey())))
+	// gw not found
+	if gw == nil {
+		return Attachment[T, *gwv1.Gateway]{
+			Resource: resource, Target: nil, Section: ref.section,
+			Error: AttachmentErrTargetNotFound,
+		}, AttachmentErrTargetNotFound
+	}
+	// no need for section
+	if ref.section == "" {
+		return Attachment[T, *gwv1.Gateway]{Resource: resource, Target: gw}, nil
+	}
+	// try find section
+	for _, l := range gw.Spec.Listeners {
+		if string(l.Name) == ref.section {
+			return Attachment[T, *gwv1.Gateway]{Resource: resource, Target: gw, Section: ref.section}, nil
+		}
+	}
+	// no section found
+	return Attachment[T, *gwv1.Gateway]{
+		Resource: resource, Target: gw, Section: ref.section,
+		Error: AttachmentErrSectionNotFound,
+	}, AttachmentErrSectionNotFound
+}

--- a/projects/gateway2/krtquery/httproute.go
+++ b/projects/gateway2/krtquery/httproute.go
@@ -1,0 +1,395 @@
+package krtquery
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	k8sptr "k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/ptr"
+	"istio.io/istio/pkg/slices"
+
+	"github.com/solo-io/gloo/projects/gateway2/query"
+	"github.com/solo-io/gloo/projects/gateway2/translator/backendref"
+	"github.com/solo-io/gloo/projects/gateway2/wellknown"
+)
+
+type (
+	GatewayHTTPRoute = Attachment[*query.HTTPRouteInfo, *gwv1.Gateway]
+	ServiceHTTPRoute = Attachment[*query.HTTPRouteInfo, *corev1.Service]
+)
+
+var _ krt.ResourceNamer = &GatewayHTTPRoute{}
+
+type krtKey struct{}
+
+var NonKRTError = fmt.Errorf("Called from outside a KRT Context")
+
+// WithKRT allows wrapping the krt HandlerContext in a Go context.
+func WithKRT(ctx context.Context, krtctx krt.HandlerContext) context.Context {
+	return context.WithValue(ctx, krtKey{}, krtctx)
+}
+
+func GetKRT(ctx context.Context) (krt.HandlerContext, error) {
+	krtctx, ok := ctx.Value(krtKey{}).(krt.HandlerContext)
+	if !ok {
+		return nil, NonKRTError
+	}
+	return krtctx, nil
+}
+
+func (q *Queries) HTTPRoutesForGateway(ctx krt.HandlerContext, gw *gwv1.Gateway) (query.RoutesForGwResult, error) {
+	result := query.RoutesForGwResult{
+		ListenerResults: map[string]*query.ListenerResult{},
+	}
+
+	// perform per-listener validation (only error is bad selectors for allowedRoutes)
+	for _, l := range gw.Spec.Listeners {
+		if l.AllowedRoutes.Namespaces.From != nil && *l.AllowedRoutes.Namespaces.From == gwv1.NamespacesFromSelector && l.AllowedRoutes.Namespaces.Selector == nil {
+			lr := result.ListenerResults[string(l.Name)]
+			if lr == nil {
+				lr = &query.ListenerResult{}
+				result.ListenerResults[string(l.Name)] = lr
+			}
+			lr.Error = fmt.Errorf("selector must be set")
+		}
+	}
+
+	// aggregate successfully attached routes per-listener
+	routes := q.GatewayHTTPRoutes.FetchAttachmentsTo(ctx, gw, "")
+	for _, a := range routes {
+		if a.Section == "" {
+			continue
+		}
+		lr := result.ListenerResults[a.Section]
+		if lr == nil {
+			lr = &query.ListenerResult{}
+			result.ListenerResults[string(a.Section)] = lr
+		}
+		lr.Routes = append(lr.Routes, a.Resource)
+	}
+
+	// aggregate errored routes
+	errors := q.GatewayHTTPRoutes.FetchAttachmentsTo(ctx, gw, "")
+	for _, a := range errors {
+		result.RouteErrors = append(result.RouteErrors, &query.RouteError{
+			Route:     a.Resource.HTTPRoute,
+			ParentRef: a.Resource.ParentRef,
+			Error:     toQueryError(a.Error),
+		})
+	}
+
+	return result, nil
+}
+
+// this is ugly
+func toQueryError(err error) query.Error {
+	var reason gwv1.RouteConditionReason
+	switch err {
+	case query.ErrNotAllowedByListeners:
+		reason = gwv1.RouteReasonNotAllowedByListeners
+	case query.ErrNoMatchingParent:
+		reason = gwv1.RouteReasonNoMatchingParent
+	case query.ErrNoMatchingListenerHostname:
+		reason = gwv1.RouteReasonNoMatchingListenerHostname
+	}
+	return query.Error{
+		E:      err,
+		Reason: reason,
+	}
+}
+
+// routesForGateway are root routes that attach directly to the gateway.
+func (q *Queries) routesForGateway(
+	ctx context.Context,
+) IndexedAttachments[*query.HTTPRouteInfo, *gwv1.Gateway] {
+	// One HTTPRoute to many attached listeners.
+	gwRoutes := krt.NewManyCollection(
+		q.HTTPRoutes,
+		func(ctx krt.HandlerContext, hr *gwv1.HTTPRoute) []GatewayHTTPRoute {
+			var out []GatewayHTTPRoute
+			for _, ref := range getParentRefsForGw(hr) {
+
+				// first make sure the referenced gateway exists
+				gw := ptr.Flatten(krt.FetchOne(ctx, q.Gateways, krt.FilterKey(parentRef(hr, ref).targetResourceKey())))
+				if gw == nil {
+					// when it's missing the errored attachment still needed for reports
+					out = append(out, GatewayHTTPRoute{
+						Resource: &query.HTTPRouteInfo{HTTPRoute: *hr, ParentRef: ref},
+						Section:  string(ptr.OrDefault(ref.SectionName, "")),
+						Error:    AttachmentErrTargetNotFound,
+					})
+					continue
+				}
+
+				// for HTTPRoute -> Gateway, unspecified Section means all listeners.
+				var sections []gwv1.SectionName
+				if ref.SectionName != nil {
+					sections = []gwv1.SectionName{*ref.SectionName}
+				} else {
+					sections = slices.Map(gw.Spec.Listeners, func(l gwv1.Listener) gwv1.SectionName {
+						return l.Name
+					})
+				}
+
+				for _, section := range sections {
+					info := &query.HTTPRouteInfo{HTTPRoute: *hr, ParentRef: ref}
+					attachment := GatewayHTTPRoute{
+						Resource: info,
+						Target:   gw,
+						Section:  string(section),
+					}
+					l := slices.FindFunc(gw.Spec.Listeners, func(l gwv1.Listener) bool {
+						return l.Name == section
+					})
+					if l == nil {
+						attachment.Error = AttachmentErrSectionNotFound
+						out = append(out, attachment)
+						continue
+					}
+					if !allowedRouteKind(l, metav1.GroupKind{Group: gwv1.GroupName, Kind: wellknown.HTTPRouteKind}) {
+						continue
+					}
+					if !allowedRouteNamespace(gw, l, hr.GetNamespace()) {
+						continue
+					}
+
+					// errors on referenced delgated routes are reported as part of HTTPRoute plugin
+					// the errors we find here will live in the Backends map
+					info.Backends = q.resolveRouteBackends(ctx, hr)
+					info.Children = q.delegatedChildren(ctx, hr, nil)
+
+					out = append(out, attachment)
+				}
+			}
+			return out
+		},
+	)
+
+	return CreateAttachmentIndexes(gwRoutes)
+}
+
+// HTTPRouteChain recursively resolves all backends of the given HTTPRoute.
+// While this includes delegated HTTPRoutes, validation of matchers is not
+// applied here. Instead, matcher processing is handled during translation.
+// Errors for unresolved or cyclic backend references will be surfaced on the
+// HTTPRouteInfo.
+func (q *Queries) HTTPRouteChain(
+	ctx krt.HandlerContext,
+	route gwv1.HTTPRoute,
+	hostnames []string,
+	parentRef gwv1.ParentReference,
+) *query.HTTPRouteInfo {
+	return &query.HTTPRouteInfo{
+		HTTPRoute:         route,
+		HostnameOverrides: hostnames,
+		ParentRef:         parentRef,
+		Backends:          q.resolveRouteBackends(ctx, &route),
+		Children:          q.delegatedChildren(ctx, &route, nil),
+	}
+}
+
+// krt equiv of query.getDelegatedChildren
+func (q *Queries) delegatedChildren(
+	ctx krt.HandlerContext,
+	parent *gwv1.HTTPRoute,
+	visited sets.Set[types.NamespacedName],
+) query.BackendMap[[]*query.HTTPRouteInfo] {
+	if visited == nil {
+		visited = sets.New[types.NamespacedName]()
+	}
+	parentRef := namespacedName(parent)
+	visited.Insert(parentRef)
+
+	children := query.NewBackendMap[[]*query.HTTPRouteInfo]()
+	for _, parentRule := range parent.Spec.Rules {
+		for _, backendRef := range parentRule.BackendRefs {
+			if !backendref.RefIsHTTPRoute(backendRef.BackendObjectReference) {
+				continue
+			}
+			referencedRoutes, err := q.fetchChildRoutes(
+				ctx,
+				parent.Namespace,
+				backendRef,
+			)
+			if err != nil {
+				children.AddError(backendRef.BackendObjectReference, err)
+				continue
+			}
+
+			var backendRefChildren []*query.HTTPRouteInfo
+			for _, childRoute := range referencedRoutes {
+				childRef := namespacedName(childRoute)
+				if visited.Has(childRef) {
+					err := fmt.Errorf("ignoring cyclical child route %s for parent %s: %w", parentRef, childRef, query.ErrCyclicReference)
+					children.AddError(backendRef.BackendObjectReference, err)
+					// don't resolve child routes; the entire backendRef is invalid?
+					break
+				}
+				routeInfo := &query.HTTPRouteInfo{
+					HTTPRoute: *childRoute,
+					ParentRef: gwv1.ParentReference{
+						Group:     k8sptr.To(gwv1.Group(wellknown.GatewayGroup)),
+						Kind:      k8sptr.To(gwv1.Kind(wellknown.HTTPRouteKind)),
+						Namespace: k8sptr.To(gwv1.Namespace(parent.Namespace)),
+						Name:      gwv1.ObjectName(parent.Name),
+					},
+					Backends: q.resolveRouteBackends(ctx, childRoute),
+					Children: q.delegatedChildren(ctx, childRoute, visited),
+				}
+				backendRefChildren = append(backendRefChildren, routeInfo)
+			}
+			children.Add(backendRef.BackendObjectReference, backendRefChildren)
+		}
+	}
+	return children
+}
+
+// TODO check reference grants
+func (q *Queries) resolveRouteBackends(
+	ctx krt.HandlerContext,
+	hr *gwv1.HTTPRoute,
+) query.BackendMap[client.Object] {
+	out := query.NewBackendMap[client.Object]()
+	for _, rule := range hr.Spec.Rules {
+		for _, backendRef := range rule.BackendRefs {
+			// TODO(stevenctl) we should probably report invalid kinds of backendRef.
+			// We don't do it yet today, and we need some extensibilty here so I'm
+			// not hanlding it in the move to krt; will do it with ServiceEntry work.
+			resolvedBackend, err := q.GetGrantedRef(
+				ctx,
+				HTTPRouteGK,
+				hr.GetNamespace(),
+				backendref.GroupKind(backendRef.BackendObjectReference),
+				string(backendRef.BackendObjectReference.Name),
+				nsPtrToString(backendRef.BackendObjectReference.Namespace),
+			)
+			if err != nil {
+				out.AddError(backendRef.BackendObjectReference, err)
+				continue
+			} else if resolvedBackend == nil {
+				// should never happen if err is nil
+				out.AddError(backendRef.BackendObjectReference, query.ErrUnresolvedReference)
+				continue
+			}
+
+			out.Add(backendRef.BackendObjectReference, resolvedBackend)
+
+		}
+	}
+	return out
+}
+
+func (q *Queries) fetchChildRoutes(
+	ctx krt.HandlerContext,
+	parentNamespace string,
+	backendRef gwv1.HTTPBackendRef,
+) ([]*gwv1.HTTPRoute, error) {
+	delegatedNs := parentNamespace
+	if backendRef.Namespace != nil {
+		delegatedNs = string(*backendRef.Namespace)
+	}
+
+	// if the name is missing or '*' that means all routes in the namespace.
+	filter := []krt.FetchOption{krt.FilterIndex(q.httpRoutesByNamespace, delegatedNs)}
+	// if the name is specified, fetch only that one
+	if backendRef.Name != "" && backendRef.Name != "*" {
+		filter = append(filter, krt.FilterObjectName(types.NamespacedName{
+			Name:      string(backendRef.Name),
+			Namespace: delegatedNs,
+		}))
+	}
+
+	var refChildren []*gwv1.HTTPRoute
+	fetched := krt.Fetch(ctx, q.HTTPRoutes, filter...)
+	refChildren = append(refChildren, fetched...)
+
+	if len(refChildren) == 0 {
+		return nil, query.ErrUnresolvedReference
+	}
+	return refChildren, nil
+}
+
+// getParentRefsForGw filters refs to only include those of kind Gateway
+// If there is no Group/Kind, assume it's pointing to a Gateway.
+func getParentRefsForGw(hr *gwv1.HTTPRoute) []gwv1.ParentReference {
+	var ret []gwv1.ParentReference
+	for _, pRef := range hr.Spec.ParentRefs {
+		if pRef.Group != nil && *pRef.Group != gwv1.GroupName {
+			continue
+		}
+		if pRef.Kind != nil && *pRef.Kind != wellknown.GatewayKind {
+			continue
+		}
+		ret = append(ret, pRef)
+	}
+	return ret
+}
+
+func allowedRouteKind(l *gwv1.Listener, gk metav1.GroupKind) bool {
+	// default to protocol based
+	var allowedKinds []metav1.GroupKind
+	switch l.Protocol {
+	case gwv1.HTTPSProtocolType:
+		fallthrough
+	case gwv1.HTTPProtocolType:
+		allowedKinds = []metav1.GroupKind{{Kind: wellknown.HTTPRouteKind, Group: gwv1.GroupName}}
+		// TLS and TCP unsupported
+	case gwv1.TLSProtocolType:
+		fallthrough
+	case gwv1.TCPProtocolType:
+		allowedKinds = []metav1.GroupKind{{}}
+	case gwv1.UDPProtocolType:
+		allowedKinds = []metav1.GroupKind{{}}
+	// custom protocols can have httproutes
+	default:
+		// allow custom protocols to work (i.e. istio.io/PROXY)
+		allowedKinds = []metav1.GroupKind{{Kind: wellknown.HTTPRouteKind, Group: gwv1.GroupName}}
+	}
+
+	// listener specified
+	if l != nil && l.AllowedRoutes != nil && l.AllowedRoutes.Kinds != nil {
+		allowedKinds = slices.Map(l.AllowedRoutes.Kinds, func(k gwv1.RouteGroupKind) metav1.GroupKind {
+			gk := metav1.GroupKind{Kind: string(k.Kind), Group: gwv1.GroupName}
+			if k.Group != nil {
+				gk.Group = string(*k.Group)
+			}
+			return gk
+		})
+	}
+
+	return sets.New(allowedKinds...).Has(gk)
+}
+
+func allowedRouteNamespace(
+	gw *gwv1.Gateway,
+	l *gwv1.Listener,
+	ns string,
+) bool {
+	var allowedNamespaces *v1.RouteNamespaces
+	if l.AllowedRoutes != nil && l.AllowedRoutes.Namespaces != nil && l.AllowedRoutes.Namespaces.From != nil {
+		allowedNamespaces = l.AllowedRoutes.Namespaces
+	}
+
+	switch *allowedNamespaces.From {
+	case v1.NamespacesFromSelector:
+		sel := l.AllowedRoutes.Namespaces.Selector
+		if sel == nil {
+			// we do validation separately that reports this as an error
+			return false
+		}
+
+	case v1.NamespacesFromAll:
+		return true
+	}
+
+	return ns == gw.Namespace
+}

--- a/projects/gateway2/krtquery/krtquery.go
+++ b/projects/gateway2/krtquery/krtquery.go
@@ -1,0 +1,209 @@
+package krtquery
+
+import (
+	"context"
+
+	"github.com/solo-io/gloo/projects/gateway2/krtcollection"
+	"github.com/solo-io/gloo/projects/gateway2/query"
+	"github.com/solo-io/gloo/projects/gateway2/wellknown"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	glookubev1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/kube/apis/gloo.solo.io/v1"
+
+	"istio.io/istio/pkg/config/schema/gvr"
+	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/kclient"
+	"istio.io/istio/pkg/kube/krt"
+	"istio.io/istio/pkg/ptr"
+)
+
+type Queries struct {
+	// k8s top level
+	Services   krt.Collection[*v1.Service]
+	Secrets    krt.Collection[*v1.Secret]
+	Namespaces krt.Collection[*v1.Namespace]
+
+	// gwapi top level
+	HTTPRoutes                 krt.Collection[*gwv1.HTTPRoute]
+	httpRoutesByNamespace      krt.Index[string, *gwv1.HTTPRoute]
+	Gateways                   krt.Collection[*gwv1.Gateway]
+	GatewayClasses             krt.Collection[*gwv1.GatewayClass]
+	ReferenceGrants            krt.Collection[*gwv1beta1.ReferenceGrant]
+	referenceGrantsByNamespace krt.Index[string, *gwv1beta1.ReferenceGrant]
+
+	// gloo top level (for now we use kube types for reference grant purposes)
+	Upstreams krt.Collection[*glookubev1.Upstream]
+
+	// derived collections
+	GatewayHTTPRoutes IndexedAttachments[*query.HTTPRouteInfo, *gwv1.Gateway]
+}
+
+func New(ctx context.Context, client kube.Client) *Queries {
+	filter := kclient.Filter{}
+
+	Services := krt.WrapClient(kclient.NewFiltered[*v1.Service](client, filter), krt.WithName("Services"))
+	Secrets := krt.WrapClient(kclient.NewFiltered[*v1.Secret](client, filter), krt.WithName("Secrets"))
+	Namespaces := krt.WrapClient(kclient.NewFiltered[*v1.Namespace](client, filter), krt.WithName("Namespaces"))
+
+	HTTPRoutes := krtcollection.SetupCollectionDynamic[gwv1.HTTPRoute](ctx, client, gvr.HTTPRoute_v1, krt.WithName("HTTPRoutes"))
+	httpRoutesByNamespace := krt.NewNamespaceIndex(HTTPRoutes)
+
+	Gateways := krtcollection.SetupCollectionDynamic[gwv1.Gateway](ctx, client, gvr.KubernetesGateway_v1, krt.WithName("Gateways"))
+	GatewayClasses := krtcollection.SetupCollectionDynamic[gwv1.GatewayClass](ctx, client, gvr.KubernetesGateway_v1, krt.WithName("GatewayClasses"))
+
+	ReferenceGrants := krtcollection.SetupCollectionDynamic[gwv1beta1.ReferenceGrant](ctx, client, gvr.ReferenceGrant, krt.WithName("ReferenceGrants"))
+	referenceGrantsByNamespace := krt.NewNamespaceIndex(ReferenceGrants)
+
+	Upstreams := krtcollection.SetupCollectionDynamic[glookubev1.Upstream](
+		ctx,
+		client,
+		glookubev1.SchemeGroupVersion.WithResource("upstreams"),
+		krt.WithName("RawUpstreams"),
+	)
+
+	q := Queries{
+		Services:   Services,
+		Secrets:    Secrets,
+		Namespaces: Namespaces,
+
+		// TODO GatewayAPI types shouldn't need dynamic client
+		HTTPRoutes:                 HTTPRoutes,
+		httpRoutesByNamespace:      httpRoutesByNamespace,
+		Gateways:                   Gateways,
+		GatewayClasses:             GatewayClasses,
+		ReferenceGrants:            ReferenceGrants,
+		referenceGrantsByNamespace: referenceGrantsByNamespace,
+
+		Upstreams: Upstreams,
+	}
+
+	// build derived collections in sub-constructors
+	// using the root collections from the struct
+	q.GatewayHTTPRoutes = q.routesForGateway(ctx)
+
+	return &q
+}
+
+// supported GroupKind for GetRef.
+// There is no way to make this generic over the entire Scheme with krt.
+var (
+	ServiceGK   = metav1.GroupKind{Group: v1.GroupName, Kind: wellknown.ServiceKind}
+	SercretGK   = metav1.GroupKind{Group: v1.GroupName, Kind: wellknown.SecretKind}
+	HTTPRouteGK = metav1.GroupKind(wellknown.HTTPRouteGVK.GroupKind())
+	UpstreamGK  = metav1.GroupKind(wellknown.HTTPRouteGVK.GroupKind())
+)
+
+// GetGrantedRef allows resolving arbitrary references to objects.
+// This method will NOT enforce ReferenceGrants.
+func (q *Queries) GetUngrantedRef(
+	ctx krt.HandlerContext,
+	targetGk metav1.GroupKind,
+	targetName string,
+	targetNs string,
+) (client.Object, error) {
+	return q.getRef(ctx, targetGk, targetName, targetNs)
+}
+
+// GetGrantedRef allows resolving arbitrary references to objects.
+// This method will enforce ReferenceGrants.
+func (q *Queries) GetGrantedRef(
+	ctx krt.HandlerContext,
+	fromGk metav1.GroupKind, fromNamespace string,
+	targetGk metav1.GroupKind, targetName string, targetNs *string,
+) (client.Object, error) {
+	namespace := ptr.OrDefault(targetNs, fromNamespace)
+	if !q.referenceAllowed(
+		ctx,
+		fromGk,
+		fromNamespace,
+		targetGk,
+		targetName,
+		namespace,
+	) {
+		return nil, query.ErrMissingReferenceGrant
+	}
+	return q.getRef(ctx, targetGk, targetName, namespace)
+}
+
+func (q *Queries) getRef(
+	ctx krt.HandlerContext,
+	gk metav1.GroupKind,
+	name,
+	ns string,
+) (client.Object, error) {
+	key := types.NamespacedName{
+		Name:      name,
+		Namespace: ns,
+	}.String()
+
+	var resolvedObj client.Object
+	switch gk {
+	case ServiceGK:
+		resolvedObj = ptr.Flatten(krt.FetchOne(ctx, q.Services, krt.FilterKey(key)))
+	case HTTPRouteGK:
+		resolvedObj = ptr.Flatten(krt.FetchOne(ctx, q.Services, krt.FilterKey(key)))
+	case UpstreamGK:
+		resolvedObj = ptr.Flatten(krt.FetchOne(ctx, q.Services, krt.FilterKey(key)))
+	}
+	if resolvedObj == nil {
+		return nil, query.ErrUnresolvedReference
+	}
+	return resolvedObj, nil
+}
+
+func (q *Queries) referenceAllowed(
+	ctx krt.HandlerContext,
+	fromGk metav1.GroupKind,
+	fromNamespace string,
+	targetGk metav1.GroupKind,
+	targetName, targetNs string,
+) bool {
+	if targetNs == fromNamespace {
+		return true
+	}
+
+	// fetch grants in the targeted namespace
+	refGrants := krt.Fetch(ctx, q.ReferenceGrants, krt.FilterIndex(q.referenceGrantsByNamespace, targetNs))
+	for _, refGrant := range refGrants {
+		for _, grantFrom := range refGrant.Spec.From {
+			if string(grantFrom.Namespace) != fromNamespace {
+				continue
+			}
+			if !gkMatch(fromGk, grantFrom.Group, grantFrom.Kind) {
+				continue
+			}
+
+			for _, grantTo := range refGrant.Spec.To {
+				if gkMatch(targetGk, grantTo.Group, grantTo.Kind) {
+					if grantTo.Name == nil || string(*grantTo.Name) == targetName {
+						return true
+					}
+				}
+			}
+
+		}
+	}
+	return false
+}
+
+func gkMatch(gk metav1.GroupKind, grantGroup gwv1.Group, grantKind gwv1.Kind) bool {
+	aGroup := coreIfEmpty(gk.Group)
+	bGroup := coreIfEmpty(string(grantGroup))
+	return aGroup == bGroup && gk.Kind == string(grantKind)
+}
+
+// Note that the spec has examples where the "core" api group is explicitly specified.
+// so this helper function converts an empty string (which implies core api group) to the
+// explicit "core" api group. It should only be used in places where the spec specifies that empty
+// group means "core" api group (some place in the spec may default to the "gateway" api group instead.
+func coreIfEmpty(s string) string {
+	if s == "" {
+		return "core"
+	}
+	return s
+}

--- a/projects/gateway2/krtquery/shim.go
+++ b/projects/gateway2/krtquery/shim.go
@@ -1,0 +1,118 @@
+package krtquery
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/solo-io/gloo/projects/gateway2/query"
+	"github.com/solo-io/gloo/projects/gateway2/wellknown"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"istio.io/istio/pkg/kube/krt"
+)
+
+var _ query.GatewayQueries = &Queries{}
+
+func (q *Queries) GetBackendForRef(ctx context.Context, fromObj query.From, backendRef *gwv1.BackendObjectReference) (client.Object, error) {
+	krtctx, ok := ctx.Value(krtKey{}).(krt.HandlerContext)
+	if !ok {
+		return nil, NonKRTError
+	}
+	// backendRef defaults to Service
+	targetGk := metav1.GroupKind{
+		Group: v1.GroupName,
+		Kind:  wellknown.ServiceKind,
+	}
+	if backendRef.Kind != nil {
+		targetGk.Kind = string(*backendRef.Kind)
+	}
+	if backendRef.Group != nil {
+		targetGk.Group = string(*backendRef.Group)
+	}
+
+	return q.GetGrantedRef(
+		krtctx,
+		fromObj.GroupKind,
+		fromObj.Namespace,
+		targetGk,
+		string(backendRef.Name),
+		nsPtrToString(backendRef.Namespace),
+	)
+}
+
+// GetHTTPRouteChain resolves backends and delegated routes for a HTTPRoute
+func (q *Queries) GetHTTPRouteChain(ctx context.Context, route gwv1.HTTPRoute, hostnames []string, parentRef gwv1.ParentReference) *query.HTTPRouteInfo {
+	krtctx, ok := ctx.Value(krtKey{}).(krt.HandlerContext)
+	if !ok {
+		// TODO, just don't have a shim...
+		panic("not in krt")
+	}
+	return q.HTTPRouteChain(krtctx, route, hostnames, parentRef)
+}
+
+func (q *Queries) GetRoutesForGateway(ctx context.Context, gw *gwv1.Gateway) (query.RoutesForGwResult, error) {
+	krtctx, ok := ctx.Value(krtKey{}).(krt.HandlerContext)
+	if !ok {
+		return query.RoutesForGwResult{}, NonKRTError
+	}
+	return q.HTTPRoutesForGateway(krtctx, gw)
+}
+
+func (r *Queries) GetSecretForRef(ctx context.Context, from query.From, secretRef gwv1.SecretObjectReference) (*v1.Secret, error) {
+	krtctx, err := GetKRT(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	refGk := SercretGK
+	if secretRef.Group != nil && *secretRef.Group != gwv1.Group(SercretGK.Group) {
+		refGk.Group = string(*secretRef.Group)
+	}
+	if secretRef.Kind != nil {
+		refGk.Kind = string(*secretRef.Kind)
+	}
+	if refGk != SercretGK {
+		return nil, fmt.Errorf("only support core Secret references")
+	}
+
+	obj, err := r.GetGrantedRef(
+		krtctx,
+		from.GroupKind, from.Namespace,
+		SercretGK, string(secretRef.Name), nsPtrToString(secretRef.Namespace),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return obj.(*v1.Secret), nil
+}
+
+func (r *Queries) GetLocalObjRef(ctx context.Context, fromObj query.From, localObjRef gwv1.LocalObjectReference) (client.Object, error) {
+	krtctx, err := GetKRT(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	refGroup := ""
+	if localObjRef.Group != "" {
+		refGroup = string(localObjRef.Group)
+	}
+
+	if localObjRef.Kind == "" {
+		return nil, query.ErrLocalObjRefMissingKind
+	}
+	refKind := localObjRef.Kind
+
+	localObjGK := metav1.GroupKind{Group: refGroup, Kind: string(refKind)}
+	return r.GetUngrantedRef(krtctx, localObjGK, string(localObjRef.Name), fromObj.Namespace)
+}
+
+func nsPtrToString(ns *gwv1.Namespace) *string {
+	if ns == nil {
+		return nil
+	}
+	converted := string(*ns)
+	return &converted
+}

--- a/projects/gateway2/krtquery/util.go
+++ b/projects/gateway2/krtquery/util.go
@@ -1,0 +1,12 @@
+package krtquery
+
+import "k8s.io/apimachinery/pkg/types"
+
+type Namespaced interface {
+	GetName() string
+	GetNamespace() string
+}
+
+func namespacedName(o Namespaced) types.NamespacedName {
+	return types.NamespacedName{Name: o.GetName(), Namespace: o.GetNamespace()}
+}

--- a/projects/gateway2/query/httproute.go
+++ b/projects/gateway2/query/httproute.go
@@ -43,6 +43,11 @@ type HTTPRouteInfo struct {
 	Children BackendMap[[]*HTTPRouteInfo]
 }
 
+func (hr HTTPRouteInfo) Equals(other HTTPRouteInfo) bool {
+	// TODO!!!
+	return true
+}
+
 func (hr HTTPRouteInfo) GetName() string {
 	return hr.HTTPRoute.GetName()
 }
@@ -244,7 +249,7 @@ func (r *gatewayQueries) resolveRouteBackends(ctx context.Context, hr *gwv1.HTTP
 	out := NewBackendMap[client.Object]()
 	for _, rule := range hr.Spec.Rules {
 		for _, backendRef := range rule.BackendRefs {
-			obj, err := r.GetBackendForRef(ctx, r.ObjToFrom(hr), &backendRef.BackendObjectReference)
+			obj, err := r.GetBackendForRef(ctx, FromRoute(hr), &backendRef.BackendObjectReference)
 			if err != nil {
 				out.AddError(backendRef.BackendObjectReference, err)
 				continue

--- a/projects/gateway2/query/query_test.go
+++ b/projects/gateway2/query/query_test.go
@@ -25,10 +25,6 @@ var _ = Describe("Query", func() {
 		builder *fake.ClientBuilder
 	)
 
-	tofrom := func(o client.Object) query.From {
-		return query.FromObject{Scheme: scheme, Object: o}
-	}
-
 	BeforeEach(func() {
 		scheme = schemes.DefaultScheme()
 		builder = fake.NewClientBuilder().WithScheme(scheme)
@@ -47,7 +43,7 @@ var _ = Describe("Query", func() {
 				Name: "foo",
 			}
 
-			backend, err := gq.GetBackendForRef(context.Background(), tofrom(httpRoute()), ref)
+			backend, err := gq.GetBackendForRef(context.Background(), query.FromRoute(httpRoute()), ref)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(backend).NotTo(BeNil())
 			Expect(backend.GetName()).To(Equal("foo"))
@@ -63,7 +59,7 @@ var _ = Describe("Query", func() {
 				Namespace: nsptr("default2"),
 			}
 
-			backend, err := gq.GetBackendForRef(context.Background(), tofrom(httpRoute()), ref)
+			backend, err := gq.GetBackendForRef(context.Background(), query.FromRoute(httpRoute()), ref)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(backend).NotTo(BeNil())
 			Expect(backend.GetName()).To(Equal("foo"))
@@ -78,7 +74,7 @@ var _ = Describe("Query", func() {
 				Name:      "foo",
 				Namespace: nsptr("default2"),
 			}
-			backend, err := gq.GetBackendForRef(context.Background(), tofrom(httpRoute()), ref)
+			backend, err := gq.GetBackendForRef(context.Background(), query.FromRoute(httpRoute()), ref)
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			Expect(backend).To(BeNil())
 		})
@@ -117,7 +113,7 @@ var _ = Describe("Query", func() {
 			fakeClient := builder.WithObjects(rg, svc("default2")).Build()
 
 			gq := query.NewData(fakeClient, scheme)
-			backend, err := gq.GetBackendForRef(context.Background(), tofrom(httpRoute()), ref)
+			backend, err := gq.GetBackendForRef(context.Background(), query.FromRoute(httpRoute()), ref)
 			Expect(err).To(MatchError(query.ErrMissingReferenceGrant))
 			Expect(backend).To(BeNil())
 		})
@@ -130,7 +126,7 @@ var _ = Describe("Query", func() {
 				Namespace: nsptr("default3"),
 			}
 
-			backend, err := gq.GetBackendForRef(context.Background(), tofrom(httpRoute()), ref)
+			backend, err := gq.GetBackendForRef(context.Background(), query.FromRoute(httpRoute()), ref)
 			Expect(err).To(MatchError(query.ErrMissingReferenceGrant))
 			Expect(backend).To(BeNil())
 		})
@@ -144,7 +140,7 @@ var _ = Describe("Query", func() {
 				Name:      "foo",
 				Namespace: nsptr("default3"),
 			}
-			backend, err := gq.GetBackendForRef(context.Background(), tofrom(httpRoute()), ref)
+			backend, err := gq.GetBackendForRef(context.Background(), query.FromRoute(httpRoute()), ref)
 			Expect(err).To(MatchError(query.ErrMissingReferenceGrant))
 			Expect(backend).To(BeNil())
 		})
@@ -159,7 +155,7 @@ var _ = Describe("Query", func() {
 				Name:      "foo",
 				Namespace: nsptr("default2"),
 			}
-			backend, err := gq.GetSecretForRef(context.Background(), tofrom(gw()), ref)
+			backend, err := gq.GetSecretForRef(context.Background(), query.FromGateway(gw()), ref)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(backend).NotTo(BeNil())
 			Expect(backend.GetName()).To(Equal("foo"))

--- a/projects/gateway2/translator/backendref/types.go
+++ b/projects/gateway2/translator/backendref/types.go
@@ -3,12 +3,23 @@ package backendref
 import (
 	"fmt"
 
+	"istio.io/istio/pkg/ptr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
 	"github.com/solo-io/gloo/projects/gateway2/wellknown"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/kube/apis/gloo.solo.io/v1"
-	corev1 "k8s.io/api/core/v1"
-	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
+
+func GroupKind(ref gwv1.BackendObjectReference) metav1.GroupKind {
+	// default to core v1/Service for BackendRef
+	return metav1.GroupKind{
+		Group: string(ptr.OrDefault(ref.Group, corev1.GroupName)),
+		Kind:  string(ptr.OrDefault(ref.Kind, wellknown.ServiceKind)),
+	}
+}
 
 // RefIsService checks if the BackendObjectReference is a service
 // Note: Kind defaults to "Service" when not specified and BackendRef Group defaults to core API group when not specified.

--- a/projects/gateway2/translator/listener/gateway_listener_translator.go
+++ b/projects/gateway2/translator/listener/gateway_listener_translator.go
@@ -21,7 +21,6 @@ import (
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/ssl"
 	"github.com/solo-io/gloo/projects/gloo/pkg/utils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
-	corev1 "k8s.io/api/core/v1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -475,19 +474,19 @@ func translateSslConfig(
 	var secretRef *core.ResourceRef
 	for _, certRef := range tls.CertificateRefs {
 		// validate via query
-		secret, err := queries.GetSecretForRef(ctx, query.FromGkNs{
-			Gk: metav1.GroupKind{
+		secret, err := queries.GetSecretForRef(ctx, query.From{
+			GroupKind: metav1.GroupKind{
 				Group: gwv1.GroupName,
 				Kind:  "Gateway",
 			},
-			Ns: parentNamespace,
+			Namespace: parentNamespace,
 		}, certRef)
 		if err != nil {
 			return nil, err
 		}
 		// The resulting sslconfig will still have to go through a real translation where we run through this again.
 		// This means that while its nice to still fail early here we dont need to scrub the actual contents of the secret.
-		if _, err := sslutils.ValidateTlsSecret(secret.(*corev1.Secret)); err != nil {
+		if _, err := sslutils.ValidateTlsSecret(secret); err != nil {
 			return nil, err
 		}
 

--- a/projects/gateway2/translator/plugins/mirror/mirror_plugin.go
+++ b/projects/gateway2/translator/plugins/mirror/mirror_plugin.go
@@ -47,7 +47,7 @@ func (p *plugin) ApplyRoutePlugin(
 		return errors.Errorf("RequestMirror must have destinations")
 	}
 
-	obj, err := p.queries.GetBackendForRef(ctx, p.queries.ObjToFrom(routeCtx.Route), &config.BackendRef)
+	obj, err := p.queries.GetBackendForRef(ctx, query.FromRoute(routeCtx.Route), &config.BackendRef)
 	clusterName := query.ProcessBackendRef(
 		obj,
 		err,
@@ -55,7 +55,7 @@ func (p *plugin) ApplyRoutePlugin(
 		config.BackendRef,
 	)
 	if clusterName == nil {
-		return nil //TODO https://github.com/solo-io/gloo/pull/8890/files#r1391523183
+		return nil // TODO https://github.com/solo-io/gloo/pull/8890/files#r1391523183
 	}
 
 	switch {

--- a/projects/gateway2/translator/plugins/mirror/mirror_plugin_test.go
+++ b/projects/gateway2/translator/plugins/mirror/mirror_plugin_test.go
@@ -49,7 +49,6 @@ func TestSingleMirror(t *testing.T) {
 		},
 	}
 
-	queries.EXPECT().ObjToFrom(rt).Return(nil)
 	queries.EXPECT().GetBackendForRef(context.Background(), gomock.Any(), &filter.RequestMirror.BackendRef).Return(svc, nil)
 	plugin := mirror.NewPlugin(queries)
 	outputRoute := &v1.Route{
@@ -100,7 +99,6 @@ func TestUpstreamMirror(t *testing.T) {
 		},
 	}
 
-	queries.EXPECT().ObjToFrom(rt).Return(nil)
 	queries.EXPECT().GetBackendForRef(context.Background(), gomock.Any(), &filter.RequestMirror.BackendRef).Return(svc, nil)
 	plugin := mirror.NewPlugin(queries)
 	outputRoute := &v1.Route{
@@ -158,9 +156,7 @@ func TestUpstreamMirror(t *testing.T) {
 // 			Namespace: "foo",
 // 		},
 // 	}
-// 	queries.EXPECT().ObjToFrom(rt).Return(nil)
 // 	queries.EXPECT().GetBackendForRef(ctx.Ctx, gomock.Any(), &filter1.RequestMirror.BackendRef).Return(svc1, nil)
-// 	queries.EXPECT().ObjToFrom(rt).Return(nil)
 // 	queries.EXPECT().GetBackendForRef(ctx.Ctx, gomock.Any(), &filter2.RequestMirror.BackendRef).Return(svc2, nil)
 
 // 	plugin := mirror.NewPlugin()

--- a/projects/gateway2/translator/plugins/mirror/mocks/mock_queries.go
+++ b/projects/gateway2/translator/plugins/mirror/mocks/mock_queries.go
@@ -10,8 +10,9 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	query "github.com/solo-io/gloo/projects/gateway2/query"
+	v1 "k8s.io/api/core/v1"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
-	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	v10 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // MockGatewayQueries is a mock of GatewayQueries interface.
@@ -38,7 +39,7 @@ func (m *MockGatewayQueries) EXPECT() *MockGatewayQueriesMockRecorder {
 }
 
 // GetBackendForRef mocks base method.
-func (m *MockGatewayQueries) GetBackendForRef(arg0 context.Context, arg1 query.From, arg2 *v1.BackendObjectReference) (client.Object, error) {
+func (m *MockGatewayQueries) GetBackendForRef(arg0 context.Context, arg1 query.From, arg2 *v10.BackendObjectReference) (client.Object, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBackendForRef", arg0, arg1, arg2)
 	ret0, _ := ret[0].(client.Object)
@@ -53,7 +54,7 @@ func (mr *MockGatewayQueriesMockRecorder) GetBackendForRef(arg0, arg1, arg2 inte
 }
 
 // GetHTTPRouteChain mocks base method.
-func (m *MockGatewayQueries) GetHTTPRouteChain(arg0 context.Context, arg1 v1.HTTPRoute, arg2 []string, arg3 v1.ParentReference) *query.HTTPRouteInfo {
+func (m *MockGatewayQueries) GetHTTPRouteChain(arg0 context.Context, arg1 v10.HTTPRoute, arg2 []string, arg3 v10.ParentReference) *query.HTTPRouteInfo {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHTTPRouteChain", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*query.HTTPRouteInfo)
@@ -67,7 +68,7 @@ func (mr *MockGatewayQueriesMockRecorder) GetHTTPRouteChain(arg0, arg1, arg2, ar
 }
 
 // GetLocalObjRef mocks base method.
-func (m *MockGatewayQueries) GetLocalObjRef(arg0 context.Context, arg1 query.From, arg2 v1.LocalObjectReference) (client.Object, error) {
+func (m *MockGatewayQueries) GetLocalObjRef(arg0 context.Context, arg1 query.From, arg2 v10.LocalObjectReference) (client.Object, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLocalObjRef", arg0, arg1, arg2)
 	ret0, _ := ret[0].(client.Object)
@@ -82,7 +83,7 @@ func (mr *MockGatewayQueriesMockRecorder) GetLocalObjRef(arg0, arg1, arg2 interf
 }
 
 // GetRoutesForGateway mocks base method.
-func (m *MockGatewayQueries) GetRoutesForGateway(arg0 context.Context, arg1 *v1.Gateway) (query.RoutesForGwResult, error) {
+func (m *MockGatewayQueries) GetRoutesForGateway(arg0 context.Context, arg1 *v10.Gateway) (query.RoutesForGwResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRoutesForGateway", arg0, arg1)
 	ret0, _ := ret[0].(query.RoutesForGwResult)
@@ -97,10 +98,10 @@ func (mr *MockGatewayQueriesMockRecorder) GetRoutesForGateway(arg0, arg1 interfa
 }
 
 // GetSecretForRef mocks base method.
-func (m *MockGatewayQueries) GetSecretForRef(arg0 context.Context, arg1 query.From, arg2 v1.SecretObjectReference) (client.Object, error) {
+func (m *MockGatewayQueries) GetSecretForRef(arg0 context.Context, arg1 query.From, arg2 v10.SecretObjectReference) (*v1.Secret, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecretForRef", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.Object)
+	ret0, _ := ret[0].(*v1.Secret)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -109,18 +110,4 @@ func (m *MockGatewayQueries) GetSecretForRef(arg0 context.Context, arg1 query.Fr
 func (mr *MockGatewayQueriesMockRecorder) GetSecretForRef(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretForRef", reflect.TypeOf((*MockGatewayQueries)(nil).GetSecretForRef), arg0, arg1, arg2)
-}
-
-// ObjToFrom mocks base method.
-func (m *MockGatewayQueries) ObjToFrom(arg0 client.Object) query.From {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ObjToFrom", arg0)
-	ret0, _ := ret[0].(query.From)
-	return ret0
-}
-
-// ObjToFrom indicates an expected call of ObjToFrom.
-func (mr *MockGatewayQueriesMockRecorder) ObjToFrom(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ObjToFrom", reflect.TypeOf((*MockGatewayQueries)(nil).ObjToFrom), arg0)
 }

--- a/projects/gateway2/translator/plugins/utils/plugin_utils.go
+++ b/projects/gateway2/translator/plugins/utils/plugin_utils.go
@@ -87,7 +87,7 @@ func GetExtensionRefObj[T client.Object](
 	queries query.GatewayQueries,
 	extensionRef *gwv1.LocalObjectReference,
 ) (T, error) {
-	return GetExtensionRefObjFrom[T](ctx, queries.ObjToFrom(route), queries, extensionRef)
+	return GetExtensionRefObjFrom[T](ctx, query.FromRoute(route), queries, extensionRef)
 }
 
 func GetExtensionRefObjFrom[T client.Object](

--- a/projects/gateway2/wellknown/gwapi.go
+++ b/projects/gateway2/wellknown/gwapi.go
@@ -12,6 +12,9 @@ const (
 	// Kind string for k8s service
 	ServiceKind = "Service"
 
+	// Kind string for k8s secret
+	SecretKind = "Secret"
+
 	// Kind string for HTTPRoute resource
 	HTTPRouteKind = "HTTPRoute"
 


### PR DESCRIPTION
# Description

This PR intends to move all data-fetching for Gateway (v2) translation to happen within KRT.



## Code changes

- [ ] Move primary queries
- [ ] Move queries from plugins (VHO, RO)
- [ ] Pass krtcontext directly within translators. Use the new methods instead of the shim. 


# Context

[#k](https://github.com/solo-io/solo-projects/issues/7119)

## Interesting decisions

 In the initial PR (or at least in the draft state), I am _not_ modifying the translation code. Instead, I'm shimming the existing query interface to accept a krtcontext wrapped go context.

## Testing steps

TODO! 

## Notes for reviewers

This PR should be carefully reviewed, especially HTTPRoute and delegation logic. 

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
