### PR TITLE
fix CRDExists check

### DIFF
--- a/.github/workflows/pr-unit-tests.yaml
+++ b/.github/workflows/pr-unit-tests.yaml
@@ -6,6 +6,9 @@ name: Unit Tests
 #
 # Our historical unit tests are run via CloudBuild
 # Overtime, it would be valuable to consolidate these approaches
+env:
+  VERSION: '1.0.0-ci1'
+  GITHUB_TOKEN: ${{ github.token }}
 
 on:
   pull_request:

--- a/changelog/v1.18.0-beta35/crdcheck.yaml
+++ b/changelog/v1.18.0-beta35/crdcheck.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Fix CRD check to allow the group/kind to be missing.

--- a/pkg/schemes/extended_scheme.go
+++ b/pkg/schemes/extended_scheme.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/solo-io/gloo/projects/gateway2/wellknown"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
@@ -38,7 +39,7 @@ func CRDExists(restConfig *rest.Config, group, version, kind string) (bool, erro
 	groupVersion := fmt.Sprintf("%s/%s", group, version)
 	apiResourceList, err := discoveryClient.ServerResourcesForGroupVersion(groupVersion)
 	if err != nil {
-		if discovery.IsGroupDiscoveryFailedError(err) || meta.IsNoMatchError(err) {
+		if errors.IsNotFound(err) || discovery.IsGroupDiscoveryFailedError(err) || meta.IsNoMatchError(err) {
 			return false, nil
 		}
 		return false, err

--- a/projects/gateway2/controller/start.go
+++ b/projects/gateway2/controller/start.go
@@ -151,6 +151,7 @@ func NewControllerBuilder(ctx context.Context, cfg StartConfig) (*ControllerBuil
 		krt.WithName("AuthConfig"))
 
 	inputChannels := proxy_syncer.NewGatewayInputChannels()
+	setupLog.Info("setting up k8s gw ext")
 	k8sGwExtensions, err := cfg.ExtensionsFactory(ctx, ext.K8sGatewayExtensionsFactoryParameters{
 		Mgr:         mgr,
 		IstioClient: cfg.Client,
@@ -168,6 +169,7 @@ func NewControllerBuilder(ctx context.Context, cfg StartConfig) (*ControllerBuil
 		return nil, err
 	}
 
+	setupLog.Info("setting proxy syncer")
 	// Create the proxy syncer for the Gateway API resources
 	proxySyncer := proxy_syncer.NewProxySyncer(
 		ctx,
@@ -187,8 +189,10 @@ func NewControllerBuilder(ctx context.Context, cfg StartConfig) (*ControllerBuil
 		cfg.GlooStatusReporter,
 		cfg.SetupOpts.ProxyReconcileQueue,
 	)
+	setupLog.Info("init proxy syncer")
 	proxySyncer.Init(ctx, cfg.Debugger)
 
+	setupLog.Info("register proxy syncer")
 	if err := mgr.Add(proxySyncer); err != nil {
 		setupLog.Error(err, "unable to add proxySyncer runnable")
 		return nil, err

--- a/projects/gateway2/controller/start.go
+++ b/projects/gateway2/controller/start.go
@@ -151,7 +151,8 @@ func NewControllerBuilder(ctx context.Context, cfg StartConfig) (*ControllerBuil
 		krt.WithName("AuthConfig"))
 
 	inputChannels := proxy_syncer.NewGatewayInputChannels()
-	setupLog.Info("setting up k8s gw ext")
+
+	setupLog.Info("initializing k8sgateway extensions")
 	k8sGwExtensions, err := cfg.ExtensionsFactory(ctx, ext.K8sGatewayExtensionsFactoryParameters{
 		Mgr:         mgr,
 		IstioClient: cfg.Client,
@@ -169,8 +170,8 @@ func NewControllerBuilder(ctx context.Context, cfg StartConfig) (*ControllerBuil
 		return nil, err
 	}
 
-	setupLog.Info("setting proxy syncer")
 	// Create the proxy syncer for the Gateway API resources
+	setupLog.Info("initializing proxy syncer")
 	proxySyncer := proxy_syncer.NewProxySyncer(
 		ctx,
 		cfg.InitialSettings,
@@ -189,10 +190,7 @@ func NewControllerBuilder(ctx context.Context, cfg StartConfig) (*ControllerBuil
 		cfg.GlooStatusReporter,
 		cfg.SetupOpts.ProxyReconcileQueue,
 	)
-	setupLog.Info("init proxy syncer")
 	proxySyncer.Init(ctx, cfg.Debugger)
-
-	setupLog.Info("register proxy syncer")
 	if err := mgr.Add(proxySyncer); err != nil {
 		setupLog.Error(err, "unable to add proxySyncer runnable")
 		return nil, err

--- a/projects/gateway2/setup/ggv2setup.go
+++ b/projects/gateway2/setup/ggv2setup.go
@@ -2,11 +2,10 @@ package setup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
-
-	"errors"
 
 	"github.com/solo-io/gloo/pkg/utils/envutils"
 	"github.com/solo-io/gloo/pkg/utils/setuputils"
@@ -43,9 +42,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-var (
-	settingsGVR = glookubev1.SchemeGroupVersion.WithResource("settings")
-)
+var settingsGVR = glookubev1.SchemeGroupVersion.WithResource("settings")
 
 func createKubeClient(restConfig *rest.Config) (istiokube.Client, error) {
 	restCfg := istiokube.NewClientConfigForRestConfig(restConfig)
@@ -77,15 +74,14 @@ func getInitialSettings(ctx context.Context, c istiokube.Client, nns types.Names
 		return nil
 	}
 	return out
-
 }
 
 func StartGGv2(ctx context.Context,
 	setupOpts *bootstrap.SetupOpts,
 	uccBuilder krtcollections.UniquelyConnectedClientsBulider,
 	extensionsFactory extensions.K8sGatewayExtensionsFactory,
-	pluginRegistryFactory func(opts registry.PluginOpts) plugins.PluginRegistryFactory) error {
-
+	pluginRegistryFactory func(opts registry.PluginOpts) plugins.PluginRegistryFactory,
+) error {
 	restConfig := ctrl.GetConfigOrDie()
 
 	return StartGGv2WithConfig(ctx, setupOpts, restConfig, uccBuilder, extensionsFactory, pluginRegistryFactory, setuputils.SetupNamespaceName())
@@ -164,6 +160,7 @@ func StartGGv2WithConfig(ctx context.Context,
 		Debugger: setupOpts.KrtDebugger,
 	})
 	if err != nil {
+		logger.Error("failed building controller: ", err)
 		return err
 	}
 	/// no collections after this point

--- a/projects/gateway2/setup/ggv2setup.go
+++ b/projects/gateway2/setup/ggv2setup.go
@@ -160,7 +160,7 @@ func StartGGv2WithConfig(ctx context.Context,
 		Debugger: setupOpts.KrtDebugger,
 	})
 	if err != nil {
-		logger.Error("failed building controller: ", err)
+		logger.Error("failed initializing controller: ", err)
 		return err
 	}
 	/// no collections after this point

--- a/test/kubernetes/testutils/helper/util_test.go
+++ b/test/kubernetes/testutils/helper/util_test.go
@@ -23,8 +23,8 @@ func TestReturnsLatestPatchForMinor(t *testing.T) {
 	ctx := context.Background()
 	// this is fine because this is a public repo
 	client := githubutils.GetClientWithOrWithoutToken(ctx)
-	minor, err := getLatestReleasedPatchVersion(ctx, client, "gloo", 1, 8)
+	minor, err := getLatestReleasedPatchVersion(ctx, client, "gloo", 1, 9)
 	require.NoError(t, err)
 
-	assert.Equal(t, "v1.8.37", minor.String())
+	assert.Equal(t, "v1.9.30", minor.String())
 }


### PR DESCRIPTION
# Description

The current method of checking CRD existence fails with `error checking if TCPRoute CRD exists: the server could not find the requested resource` when I have v1 CRDs installed. 

Fixes https://github.com/k8sgateway/k8sgateway/issues/10351

## Code changes

* Check if `errors.IsNotFound` and return `false, nil`. The check didn't error, but we didn't find it. 
* A few log lines to help find where we get stuck in the setup


## Testing steps

* Manually verified it breaks without this and adding this line fixes it
* It would be nice to replicate this in `TestConfigureHTTPRouteBackingDestinationsWithServiceAndWithoutTCPRoute` style test, but I don't know how the APIServer will behave... we need it to think it never saw that group version? 